### PR TITLE
feat: close menu on click

### DIFF
--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -16,6 +16,8 @@ const Menu: FunctionComponent<{}> = () => {
   const [navOpen, setNavOpen] = useState(null);
   const pathname = usePathname();
 
+  const handleMenuItemClick = () => setNavOpen(false);
+
   return (
     <nav className="fixed w-full flex flex-col md:flex-row bg-secondary">
       <div className="flex flex-row justify-between">
@@ -50,6 +52,7 @@ const Menu: FunctionComponent<{}> = () => {
             target={item.target}
             text={item.text}
             active={pathname === item.target}
+            onClick={handleMenuItemClick}
           />
         ))}
       </ul>

--- a/components/menu/__tests__/menu.test.tsx
+++ b/components/menu/__tests__/menu.test.tsx
@@ -31,10 +31,44 @@ describe("Menu", () => {
     render(<Menu />);
 
     const burger = screen.getByRole("button");
-    userEvent.click(burger);
+    await userEvent.click(burger);
 
     await waitFor(() => {
       expect(screen.queryAllByRole("list")).toBeVisible;
     });
   });
+
+    test("closing burger menu hides links", async () => {
+      render(<Menu />);
+
+      const burger = screen.getByRole("button");
+      await userEvent.click(burger);
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole("list")).toBeVisible;
+      });
+
+      await userEvent.click(burger);
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole("list")).not.toBeInTheDocument;
+      });      
+    });
+
+    test("clicking link hides links", async () => {
+      render(<Menu />);
+
+      const burger = screen.getByRole("button");
+      await userEvent.click(burger);
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole("list")).toBeVisible;
+      });
+
+      await userEvent.click(screen.queryAllByRole("list")[0]);
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole("list")).not.toBeInTheDocument;
+      });      
+    });
 });

--- a/components/menu/menu-item/MenuItem.tsx
+++ b/components/menu/menu-item/MenuItem.tsx
@@ -6,12 +6,14 @@ const MenuItem: FunctionComponent<MenuItemProps> = ({
   active,
   target,
   text,
+  onClick,
 }) => {
   return (
     <li className="flex md:w-40 shrink-0 flex-row items-center justify-center group">
       <Link
         href={target}
         className="flex flex-row justify-center bg-secondary w-full"
+        onClick={onClick}
       >
         <p
           className={`my-4 md:mt-2 md:mb-0 text-center bg-secondary min-w-[6rem]

--- a/components/menu/menu-item/types.ts
+++ b/components/menu/menu-item/types.ts
@@ -3,4 +3,5 @@ export type MenuItemProps = {
   className?: string;
   target: string;
   text: string;
+  onClick: () => void;
 };


### PR DESCRIPTION
### What and Why

- Close the menu when a menu item is clicked so that it is closed after navigation
- This requires a child component setting state on a parent
- Fix React Testing Library act warnings for updating state 