### PR TITLE
feat: hero text element is responsive to text length

### DIFF
--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -3,6 +3,8 @@ import Image from "next/image";
 import { HeroProps } from "./types";
 
 const Hero: FunctionComponent<HeroProps> = ({ imageSource, altText, text }) => {
+  const hasLongText = text.length > 41;
+
   return (
     <div className="flex flex-row flex-wrap">
       <div className="basis-32 shrink-0 mr-6 mb-6">
@@ -15,7 +17,13 @@ const Hero: FunctionComponent<HeroProps> = ({ imageSource, altText, text }) => {
           priority
         />
       </div>
-      <p className="basis-40 shrink-0 mb-6 text-xl italic">{text}</p>
+      <p
+        className={`basis-40 ${
+          hasLongText ? "sm:basis-52" : ""
+        } shrink-0 mb-6 text-xl italic`}
+      >
+        {text}
+      </p>
     </div>
   );
 };

--- a/components/hero/__tests__/hero.test.tsx
+++ b/components/hero/__tests__/hero.test.tsx
@@ -19,5 +19,21 @@ describe("LinkCard", () => {
 
     expect(image).toBeVisible();
     expect(description).toBeVisible();
+    expect(description).not.toHaveClass("sm:basis-52");
+  });
+  test("text element is wider when over 41 characters", () => {
+    render(
+      <Hero
+        imageSource={"/image"}
+        altText={"image description"}
+        text={"A long ish hero text prop of 42 characters"}
+      />
+    );
+
+    const description = screen.getByText(
+      "A long ish hero text prop of 42 characters"
+    );
+
+    expect(description).toHaveClass("sm:basis-52");
   });
 });


### PR DESCRIPTION
### What and Why
The summary text in the Hero element was too squashed when then text is long or only 1 or 2 lines when the text is short. Making it responsive to text length it should usually run over 3 or 4 lines