### PR TITLE
feat: make link text contrast AA accessible

### DIFF
--- a/components/article/text-link/TextLink.tsx
+++ b/components/article/text-link/TextLink.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 
 const TextLink: FunctionComponent<TextLinkProps> = ({ target, children }) => {
   return (
-    <Link className="text-mjr_dark_orange font-bold underline italic" href={target} >{children}</Link>
+    <Link
+      className="text-mjr_very_dark_orange font-bold underline italic"
+      href={target}
+    >
+      {children}
+    </Link>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
         mjr_very_light_green: "#DDE6DD",
         mjr_dark_blue: "#0D2B57",
         mjr_orange: "#E07A5F",
-        mjr_very_dark_orange: "#B55940",
+        mjr_very_dark_orange: "#b8573d",
         mjr_dark_orange: "#CC6B50",
         mjr_light_orange: "#E1B0A3",
       },


### PR DESCRIPTION
### What and Why
Link text is changed to 4.96 contrast ratio to be AA accessible.