### PR TITLE
feat: make desktop submenu appear on hover

### DIFF
--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -19,7 +19,7 @@ const MENU_LIST: {
   { path: "/quality-topics", text: "Quality topics" },
   {
     path: "/the-making-of",
-    text: "The making of",
+    text: "How to make this site",
     submenuItems: [
       { target: "", text: "Starting choices" },
       { target: "/day-2-running", text: "Up and running" },

--- a/components/menu/__tests__/menu.test.tsx
+++ b/components/menu/__tests__/menu.test.tsx
@@ -16,7 +16,7 @@ describe("Menu", () => {
 
     const activeMenuLink = screen.getByText("Me and my site");
     const inactiveMenuLink = screen.getByText("Quality topics");
-    const submenu = screen.getByText("The making of");
+    const submenu = screen.getByText("How to make this site");
 
     expect(activeMenuLink).toBeVisible();
     expect(activeMenuLink).toHaveClass("border-mjr_orange");

--- a/components/menu/menu-item/MenuItem.tsx
+++ b/components/menu/menu-item/MenuItem.tsx
@@ -16,7 +16,7 @@ const MenuItem: FunctionComponent<MenuItemProps> = ({
 
   return (
     <li
-      className={`flex md:w-40 shrink-0 flex-col items-center justify-center ${backgroundColour} ${
+      className={`flex md:w-44 shrink-0 flex-col items-center justify-center ${backgroundColour} ${
         isSubmenu ? "group/submenuitem" : "group"
       }`}
     >

--- a/components/menu/submenu/Submenu.tsx
+++ b/components/menu/submenu/Submenu.tsx
@@ -16,7 +16,7 @@ const Submenu: FunctionComponent<SubmenuProps> = ({
   const handleOnClick = () => onClick();
 
   return (
-    <li className="flex md:w-40 shrink-0 flex-col items-center justify-center">
+    <li className="flex md:w-44 shrink-0 flex-col items-center justify-center group">
       <button
         onClick={onSubmenuItemClick}
         className="flex flex-row justify-center items-center bg-mjr_light_green w-full"
@@ -33,7 +33,7 @@ const Submenu: FunctionComponent<SubmenuProps> = ({
         >
           {text}
         </p>
-        <span className="ms-3 mt-1">
+        <span className="ms-3 mt-1 md:hidden">
           <Image
             className={`${submenuOpen ? "rotate-180" : ""} duration-500`}
             src="/chevron.svg"
@@ -44,7 +44,11 @@ const Submenu: FunctionComponent<SubmenuProps> = ({
           />
         </span>
       </button>
-      <ul className={`${!submenuOpen ? "hidden" : ""} w-full duration-500`}>
+      <ul
+        className={`${
+          !submenuOpen ? "hidden" : "md:hidden"
+        } w-full duration-500 md:group-hover:block`}
+      >
         <div className="md:absolute">
           {submenuItems.map((item) => (
             <MenuItem


### PR DESCRIPTION
### What and Why
The submenu items on desktop on desktop would be better to open on hover than on click
Hiding the chevron on desktop give more space for a more descriptive menu item name