### PR TITLE
feat: make illustration label text orange

### DIFF
--- a/components/article/illustration/Illustration.tsx
+++ b/components/article/illustration/Illustration.tsx
@@ -19,7 +19,7 @@ const Illustration: FunctionComponent<IllustrationProps> = ({
         height={143}
         priority
       />
-      <label className="italic" htmlFor={imageSource}>
+      <label className="italic text-mjr_very_dark_orange" htmlFor={imageSource}>
         {labelText}
       </label>
     </div>


### PR DESCRIPTION
### What and Why
Orange labels on the article illustrations makes them fit with the design scheme and be less plain