### PR TITLE
feat: make menu aria accessible

### DIFF
--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -51,14 +51,19 @@ const Menu: FunctionComponent<{}> = () => {
 
   return (
     <div className="fixed w-full flex flex-col md:flex-row">
-      <nav className="flex w-full flex-col md:flex-row bg-mjr_light_green">
+      <nav
+        id="main-menu"
+        className="flex w-full flex-col md:flex-row bg-mjr_light_green"
+      >
         <div className="flex flex-row justify-between">
           <div className="flex flex-row items-center">
             <Logo />
             <p className="md:hidden lg:block">mike james rust</p>
           </div>
           <button
-            aria-controls="menu"
+            aria-label="Menu"
+            aria-expanded={navOpen}
+            aria-controls="main-menu"
             className={"p-3 md:hidden"}
             onClick={() => setNavOpen(!navOpen)}
             data-testid="burger-menu"

--- a/components/menu/submenu/Submenu.tsx
+++ b/components/menu/submenu/Submenu.tsx
@@ -16,8 +16,14 @@ const Submenu: FunctionComponent<SubmenuProps> = ({
   const handleOnClick = () => onClick();
 
   return (
-    <li className="flex md:w-44 shrink-0 flex-col items-center justify-center group">
+    <li
+      id={`${text}-menu`}
+      className="flex md:w-44 shrink-0 flex-col items-center justify-center group"
+    >
       <button
+        aria-label={`${text} sub menu`}
+        aria-expanded={submenuOpen}
+        aria-controls={`${text}-menu`}
         onClick={onSubmenuItemClick}
         className="flex flex-row justify-center items-center bg-mjr_light_green w-full"
       >


### PR DESCRIPTION
### What and Why
accessible names, references, and states are added to the buttons to expand menu and submenus.