### PR TITLE
feat: make submenus stay visible on all device sizes when clicked

### DIFF
--- a/components/menu/submenu/Submenu.tsx
+++ b/components/menu/submenu/Submenu.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent } from "react";
 import { SubmenuProps } from "./types";
 import { usePathname } from "next/navigation";
 import MenuItem from "../menu-item";
@@ -52,7 +52,7 @@ const Submenu: FunctionComponent<SubmenuProps> = ({
       </button>
       <ul
         className={`${
-          !submenuOpen ? "hidden" : "md:hidden"
+          !submenuOpen ? "hidden" : ""
         } w-full duration-500 md:group-hover:block`}
       >
         <div className="md:absolute">


### PR DESCRIPTION
### What and Why
The submenus will now stay open if you click them regardless of which deice size you are on.
On tablet and for uses that find hover states hard to use, this will make the menu usable.
The hover states on desktop are still preserved - but overridden by click.