### PR TITLE
feat: convert css burger menu to svgs

### DIFF
--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -2,6 +2,7 @@
 
 import MenuItem from "./menu-item";
 import React, { FunctionComponent, useState } from "react";
+import Image from "next/image";
 import Logo from "../logo";
 import Submenu from "./submenu";
 import { MenuItemProps } from "./menu-item/types";
@@ -64,20 +65,27 @@ const Menu: FunctionComponent<{}> = () => {
             aria-label="Menu"
             aria-expanded={navOpen}
             aria-controls="main-menu"
-            className={"p-3 md:hidden"}
+            className={"md:hidden"}
             onClick={() => setNavOpen(!navOpen)}
             data-testid="burger-menu"
           >
-            <div
-              className={`w-6 h-0.5 bg-mjr_very_dark_orange my-1 mx-0 block duration-500
-            ${navOpen ? "-rotate-45 translate-y-[0.2rem]" : ""}`}
-              role="presentation"
-            ></div>
-            <div
-              className={`w-6 h-0.5 bg-mjr_very_dark_orange my-1 mx-0 block duration-500
-            ${navOpen ? "rotate-45 -translate-y-[0.2rem]" : ""}`}
-              role="presentation"
-            ></div>
+            {navOpen ? (
+              <Image
+                src="/burger-menu-opened.svg"
+                alt=""
+                width={30}
+                height={30}
+                priority
+              />
+            ) : (
+              <Image
+                src="/burger-menu-closed.svg"
+                alt=""
+                width={30}
+                height={30}
+                priority
+              />
+            )}
           </button>
         </div>
         <ul

--- a/public/burger-menu-closed.svg
+++ b/public/burger-menu-closed.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 240 240"  version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+   <path fill="transparent" stroke="#0D2B57" stroke-width="12" d="M40 90 L 200 90" class="path" stroke-linecap="round" stroke-linejoin="round"></path>
+   <path fill="transparent" stroke="#0D2B57" stroke-width="12" d="M40 150 L 200 150" class="path" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/public/burger-menu-opened.svg
+++ b/public/burger-menu-opened.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 240 240"  version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+   <path fill="transparent" stroke="#0D2B57" stroke-width="12" d="M65 65 L 175 175" class="path" stroke-linecap="round" stroke-linejoin="round"></path>
+   <path fill="transparent" stroke="#0D2B57" stroke-width="12" d="M65 175 L 175 65" class="path" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>


### PR DESCRIPTION
### What and Why
The burger menu created through css is not as clean as it should be. Simple svgs that don't animate are more resilient to different devices. 