### PR TITLE
feat: globally remove default focus state and add focus-visible

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,3 +8,24 @@
     transition-duration: 0s !important;
   }
 }
+
+/* accessibility focus overrides */
+
+*:focus-visible {
+  --tw-ring-offset-width: 0px;
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(244 114 182 / var(--tw-ring-opacity));
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  border-radius: 0.125rem /* 2px */;
+  z-index: 90;
+}
+
+*:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}

--- a/components/menu/menu-item/MenuItem.tsx
+++ b/components/menu/menu-item/MenuItem.tsx
@@ -22,7 +22,7 @@ const MenuItem: FunctionComponent<MenuItemProps> = ({
     >
       <Link
         href={target}
-        className="flex flex-row justify-center  w-full"
+        className="flex flex-row justify-center w-full"
         onClick={onClick}
       >
         <p


### PR DESCRIPTION
### What and Why

users who control using the keyboard need clear visibility of which element the tab is on. 
The default for this was both ugly and often hidden behind other items.