### PR TITLE
feat: improve layout of all articles page

### DIFF
--- a/app/how-to-make-a-website/page.tsx
+++ b/app/how-to-make-a-website/page.tsx
@@ -14,15 +14,17 @@ export default function TheMakingOf() {
     <>
       <div className="px-2">
         <PageHeading>How to make this site</PageHeading>
-        <Hero
-          imageSource={"/how-to-make-a-website/searching.jpg"}
-          altText={
-            "A red squirrel in a maze using a signpost to find the way to go "
-          }
-          text={"All the articles in one place"}
-        />
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 sm:pt-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 sm:pt-4 justify-items-center">
+        <div className="m-6 max-w-[20rem]">
+          <Hero
+            imageSource={"/how-to-make-a-website/searching.jpg"}
+            altText={
+              "A red squirrel in a maze using a signpost to find the way to go "
+            }
+            text={"All the articles in one place"}
+          />
+        </div>
         {makingOfMetaData.pages.map((item) => (
           <LinkCard
             key={item.uri}
@@ -30,6 +32,7 @@ export default function TheMakingOf() {
             heading={item.menuText}
             description={item.linkDescription}
             imageData={item.imageData}
+            landscape={true}
           />
         ))}
       </div>

--- a/components/link-card/LinkCard.tsx
+++ b/components/link-card/LinkCard.tsx
@@ -8,22 +8,23 @@ const LinkCard: FunctionComponent<LinkCardProps> = ({
   heading,
   description,
   imageData,
+  landscape,
 }) => {
   return (
     <Link
       href={target}
       className="p-2 m-2 max-w-[20rem] min-h-[8rem] group border-2 border-mjr_very_light_orange rounded-lg flex"
     >
-      <div className="p-2 rounded-md bg-mjr_very_light_green hover:bg-mjr_light_green ease-out flex-stretch w-full">
+      <div className="p-2 rounded-md bg-mjr_very_light_green hover:bg-mjr_light_green flex-stretch w-full">
         <h2 className="font-bold py-2 text-center">{heading}</h2>
         <Image
-          className="rounded-lg m-auto"
+          className={`rounded-lg ${landscape ? "float-left mr-2" : ""}`}
           src={imageData.source}
           alt={imageData.altText}
-          width={260}
-          height={143}
+          width={landscape ? 100 : 260}
+          height={landscape ? 100 : 260}
         />
-        <p className="text-sm p-3">{description}</p>
+        <p className="text-sm">{description}</p>
       </div>
     </Link>
   );

--- a/components/link-card/types.ts
+++ b/components/link-card/types.ts
@@ -6,4 +6,5 @@ export type LinkCardProps = {
     source: string,
     altText: string,
   };
+  landscape?: boolean, 
 };


### PR DESCRIPTION
### What and Why

Add landscape layout to link cards so that they can show more cards with less scrolling on mobile.
Update the grid layout to use landscape and improved use of grid to display the content better