### PR TITLE
feat: unify grid alignment

### DIFF
--- a/app/how-to-make-a-website/page.tsx
+++ b/app/how-to-make-a-website/page.tsx
@@ -15,7 +15,7 @@ export default function TheMakingOf() {
       <div className="px-2">
         <PageHeading>How to make this site</PageHeading>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 sm:pt-4 justify-items-center">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 sm:pt-4 justify-items-center sm:gap-2">
         <div className="m-6 max-w-[20rem]">
           <Hero
             imageSource={"/how-to-make-a-website/searching.jpg"}

--- a/components/link-card/LinkCard.tsx
+++ b/components/link-card/LinkCard.tsx
@@ -13,7 +13,7 @@ const LinkCard: FunctionComponent<LinkCardProps> = ({
   return (
     <Link
       href={target}
-      className="p-2 m-2 max-w-[20rem] min-h-[8rem] group border-2 border-mjr_very_light_orange rounded-lg flex"
+      className="p-2 m-2 max-w-[20rem] w-full min-h-[8rem] group border-2 border-mjr_very_light_orange rounded-lg flex"
     >
       <div className="p-2 rounded-md bg-mjr_very_light_green hover:bg-mjr_light_green flex-stretch w-full">
         <h2 className="font-bold py-2 text-center">{heading}</h2>


### PR DESCRIPTION
### What and Why

On mobile not all of the link cards filled the grid width
When they fill the grid width they need a grid gap